### PR TITLE
avoid string conversion on (potentially) binary data

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -38,7 +38,7 @@ public:
     }
 
     // to be called from c++ side
-    void on_response(const std::string data) {
+    void on_response(boost::python::object data) {
         try {
             call_method<void>(self, "on_response", data);
         } catch(error_already_set const&) {
@@ -47,7 +47,7 @@ public:
     }
 
     // to be called from python side
-    static void default_on_response(GATTResponse& self_, const std::string data) {
+    static void default_on_response(GATTResponse& self_, boost::python::object data) {
         self_.GATTResponse::on_response(data);
     }
 };

--- a/src/gattlib.h
+++ b/src/gattlib.h
@@ -80,7 +80,6 @@ public:
 	GATTResponse(PyObject* p);
 	virtual ~GATTResponse() {};
 
-	virtual void on_response(const std::string data);
 	virtual void on_response(boost::python::object data);
 	boost::python::list received();
 	bool wait(uint16_t timeout);


### PR DESCRIPTION
This one is potentially more contentious, but I believe correct.

For the vast majority of applications, most of the interesting data transferred is going to be binary. Even in cases (such as device name/manufacturer name/etc values) where the specification states the values are string data, you can't rely on the device implementation to get that correct. (Implementation quality varies widely, so you are pretty much guaranteed to see undecodeable garbage eventually.)

On such data we must absolutely avoid any automatic attempt to convert to a python str. That will raise an error when (not if) the conversion fails. And since we are mostly going to be triggering this from a non-python context (the IO thread) before calling into python, there is nowhere for that error to go. Even if there was, any attached python code didn't trigger this, has no way of avoiding it, and no way of recovering afterwards. Basically the only safe place to attempt the conversion is firmly within the python side when it knows the returned data should be text, perhaps after it has validated the data or at least installed its own exception handler around the conversion.