### PR TITLE
don't leak refcount when gatt_connect() fails

### DIFF
--- a/src/gattlib.cpp
+++ b/src/gattlib.cpp
@@ -290,6 +290,7 @@ GATTRequester::connect(
 
     if (_channel == NULL) {
         _state = STATE_DISCONNECTED;
+        decref();
 
         std::string msg(gerr->message);
         int ecode = gerr->code;


### PR DESCRIPTION
Something I noticed when trying to repro #5 - if gatt_connect() returns NULL then it doesn't call the callback - so we must remove the protective reference that my previous change added ourselves in that case, otherwise the GATTRequester object can never be cleaned up.

Conversely the callback should be called eventually if it returns non-NULL. There is a slight additional problem there that if check_channel() times out first, the two halves get out of sync which makes re-using the device/connection impossible (the connect syscall returns EBUSY) until that has been cleaned up. That's a more fundamental problem and I'm still trying to think of a good way of dealing with that. (I suspect the approach of having a separate "front-end timeout" and "back-end timeout" may have to be modified. Either that or have a way for the front-end to fully cancel any in-progress operation the back-end is doing.)