### PR TITLE
improve thread safety for our glib callback thread

### DIFF
--- a/src/bluez/attrib/gattrib.c
+++ b/src/bluez/attrib/gattrib.c
@@ -223,13 +223,13 @@ static void attrib_destroy(GAttrib *attrib)
 	attrib->events = NULL;
 
 	if (attrib->timeout_watch > 0)
-		g_source_remove(attrib->timeout_watch);
+		x_g_source_remove(attrib->timeout_watch);
 
 	if (attrib->write_watch > 0)
-		g_source_remove(attrib->write_watch);
+		x_g_source_remove(attrib->write_watch);
 
 	if (attrib->read_watch > 0)
-		g_source_remove(attrib->read_watch);
+		x_g_source_remove(attrib->read_watch);
 
 	if (attrib->io)
 		g_io_channel_unref(attrib->io);
@@ -362,7 +362,7 @@ static gboolean can_write_data(GIOChannel *io, GIOCondition cond,
 	cmd->sent = true;
 
 	if (attrib->timeout_watch == 0)
-		attrib->timeout_watch = g_timeout_add_seconds(GATT_TIMEOUT,
+		attrib->timeout_watch = x_g_timeout_add_seconds(GATT_TIMEOUT,
 						disconnect_timeout, attrib);
 
 	return FALSE;
@@ -382,7 +382,7 @@ static void wake_up_sender(struct _GAttrib *attrib)
 		return;
 
 	attrib = g_attrib_ref(attrib);
-	attrib->write_watch = g_io_add_watch_full(attrib->io,
+	attrib->write_watch = x_g_io_add_watch_full(attrib->io,
 				G_PRIORITY_DEFAULT, G_IO_OUT,
 				can_write_data, attrib, destroy_sender);
 }
@@ -454,7 +454,7 @@ static gboolean received_data(GIOChannel *io, GIOCondition cond, gpointer data)
 		return TRUE;
 
 	if (attrib->timeout_watch > 0) {
-		g_source_remove(attrib->timeout_watch);
+		x_g_source_remove(attrib->timeout_watch);
 		attrib->timeout_watch = 0;
 	}
 
@@ -509,7 +509,7 @@ GAttrib *g_attrib_new(GIOChannel *io, guint16 mtu)
 	attrib->requests = g_queue_new();
 	attrib->responses = g_queue_new();
 
-	attrib->read_watch = g_io_add_watch(attrib->io,
+	attrib->read_watch = x_g_io_add_watch(attrib->io,
 			G_IO_IN | G_IO_HUP | G_IO_ERR | G_IO_NVAL,
 			received_data, attrib);
 

--- a/src/bluez/btio/btio.h
+++ b/src/bluez/btio/btio.h
@@ -26,6 +26,24 @@
 
 #include <glib.h>
 
+/* These glib overrides ensure that all our callbacks fire on the
+ * correct thread. */
+void bt_io_set_context(GMainContext *c);
+guint x_g_io_add_watch(GIOChannel *channel,
+                       GIOCondition condition,
+                       GIOFunc func,
+                       gpointer user_data);
+guint x_g_io_add_watch_full(GIOChannel *channel,
+                            gint priority,
+                            GIOCondition condition,
+                            GIOFunc func,
+                            gpointer user_data,
+                            GDestroyNotify notify);
+guint x_g_timeout_add_seconds(guint interval,
+                              GSourceFunc function,
+                              gpointer data);
+gboolean x_g_source_remove(guint tag);
+
 #define BT_IO_ERROR bt_io_error_quark()
 
 GQuark bt_io_error_quark(void);

--- a/src/gattlib.cpp
+++ b/src/gattlib.cpp
@@ -53,7 +53,8 @@ IOService::start() {
         PyEval_InitThreads();
     }
 
-    boost::thread iothread(*this);
+    boost::thread iothread(std::bind(&IOService::operator(), this));
+    start_event.wait(10);
 }
 
 void
@@ -63,10 +64,17 @@ IOService::stop() {
 
 void
 IOService::operator()() {
-    event_loop = g_main_loop_new(NULL, FALSE);
+    context = g_main_context_new();
+    g_main_context_push_thread_default(context);
+    event_loop = g_main_loop_new(context, FALSE);
+    bt_io_set_context(context);
+    start_event.set();
 
     g_main_loop_run(event_loop);
     g_main_loop_unref(event_loop);
+    bt_io_set_context(NULL);
+    g_main_context_pop_thread_default(context);
+    g_main_context_unref(context);
 }
 
 static volatile IOService _instance(true);
@@ -298,7 +306,7 @@ GATTRequester::connect(
     }
 
     incref();
-    g_io_add_watch(_channel, G_IO_HUP, disconnect_cb, (gpointer)this);
+    x_g_io_add_watch(_channel, G_IO_HUP, disconnect_cb, (gpointer)this);
     if (wait) {
         PyThreadsGuard guard;
         check_channel();

--- a/src/gattlib.h
+++ b/src/gattlib.h
@@ -33,7 +33,9 @@ public:
 	void operator()();
 
 private:
+	GMainContext* context;
 	GMainLoop* event_loop;
+	Event start_event;
 };
 
 class BTIOException : public std::runtime_error


### PR DESCRIPTION
This hopefully fixes #5 and #6 - I believe they are different symptoms of the same underlying problem. It's a bit ugly, I'm sure you won't like it. (In particular I dislike having to make changes to the embedded copy of bluez, but I don't see a way around that.)

Attached is my minimal repro case: it can take a while to trip, but it does get there in the end.
[btcrash.py.txt](https://github.com/oscaracena/pygattlib/files/5397855/btcrash.py.txt)

The basic problem is the current IOService. GLib has two related classes here, GMainLoop and GMainContext. You create a new GMainLoop to catch callbacks from BT operations. But GMainLoop is actually a very thin shim that essentially just executes the while() loop dispatching events - events that *actually* belong to the GMainContext. Since you don't create one of those, your GMainLoop gets attached to the default GMainContext.

From https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html:

>To allow multiple independent sets of sources to be handled in different threads, each source is associated with a GMainContext. A GMainContext can only be running in a single thread, but sources can be added to it and removed from it from other threads. All functions which operate on a GMainContext or a built-in GSource are thread-safe.

Since you run your GMainLoop (attached to the default GMainContext) on a new separate thread, any other part of the process which also tries to run the GLib event loop will violate that single-thread constraint.

What *that* means is that the same event can be retrieved and dispatched by both the IOService thread and another thread at exactly the same time. If the timing is such that one thread destroys the event before the other can dispatch it, then you see #5 which is saying that the GSource's internals are invalid (because it has already been freed). If both threads manage to execute the callback before one of them can destroy the GSource, then you get #6, which happens when both instances of the callback unref "their" reference to the GAttrib object, causing attrib_destroy to get called twice (and attempt to free an already NULLed out requests or responses queue.)

The fix is to create our own GMainContext and make sure that every event source we create gets attached to it and not the default one. That's a bit awkward since despite telling you you have to do this in the documentation, GLib gives you remarkably little help here. None of the normal convenience wrappers have context-aware versions so you have to make your own out of more primitive functions. And of course every single call that creates a new source has to be modified accordingly, now and in the future.