### PR TITLE
add new functions for included services, descriptors, connection parameters, MTU exchange

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -179,6 +179,14 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
         GATTRequester::discover_characteristics_async, 1, 4)
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
+        GATTRequester_discover_descriptors_overloads,
+        GATTRequester::discover_descriptors, 0, 3)
+
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
+        GATTRequester_discover_descriptors_async_overloads,
+        GATTRequester::discover_descriptors_async, 1, 4)
+
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
         GATTResponse_wait_overloads,
         GATTResponse::wait_locked, 0, 1)
 
@@ -272,6 +280,10 @@ BOOST_PYTHON_MODULE(gattlib) {
         .def("on_connect_failed", &GATTRequesterCb::default_on_connect_failed)
         .def("disconnect", &GATTRequester::disconnect)
         .def("on_disconnect", &GATTRequesterCb::default_on_disconnect)
+        .def("update_connection_parameters", boost::python::raw_function(GATTRequester::update_connection_parameters_kwarg,1))
+        .def("exchange_mtu", &GATTRequester::exchange_mtu)
+        .def("exchange_mtu_async", &GATTRequester::exchange_mtu_async)
+        .def("set_mtu", &GATTRequester::set_mtu)
         .def("read_by_handle", &GATTRequester::read_by_handle)
         .def("read_by_handle_async", &GATTRequester::read_by_handle_async)
         .def("read_by_uuid", &GATTRequester::read_by_uuid)
@@ -279,18 +291,28 @@ BOOST_PYTHON_MODULE(gattlib) {
         .def("write_by_handle", &GATTRequester::write_by_handle)
         .def("write_by_handle_async", &GATTRequester::write_by_handle_async)
         .def("write_cmd", &GATTRequester::write_cmd)
+        .def("enable_notifications", &GATTRequester::enable_notifications)
+        .def("enable_notifications_async", &GATTRequester::enable_notifications_async)
         .def("on_notification", &GATTRequesterCb::default_on_notification)
         .def("on_indication", &GATTRequesterCb::default_on_indication)
         .def("discover_primary", &GATTRequester::discover_primary,
                 "returns a list with of primary services,"
                 " with their handles and UUIDs.")
         .def("discover_primary_async", &GATTRequester::discover_primary_async)
+        .def("find_included", &GATTRequester::find_included)
+        .def("find_included_async", &GATTRequester::find_included_async)
         .def("discover_characteristics",
                 &GATTRequester::discover_characteristics,
                 GATTRequester_discover_characteristics_overloads())
         .def("discover_characteristics_async",
                 &GATTRequester::discover_characteristics_async,
-                GATTRequester_discover_characteristics_async_overloads());
+                GATTRequester_discover_characteristics_async_overloads())
+        .def("discover_descriptors",
+                &GATTRequester::discover_descriptors,
+                GATTRequester_discover_descriptors_overloads())
+        .def("discover_descriptors_async",
+                &GATTRequester::discover_descriptors_async,
+                GATTRequester_discover_descriptors_async_overloads());
 
     register_ptr_to_python<GATTResponse*>();
 

--- a/src/gattlib.cpp
+++ b/src/gattlib.cpp
@@ -7,6 +7,7 @@
 #include <boost/python/dict.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/str.hpp>
+#include <boost/python/long.hpp>
 #include <sys/ioctl.h>
 #include <iostream>
 
@@ -40,6 +41,52 @@ public:
 
 private:
     PyGILState_STATE _state;
+};
+
+class PyKwargsExtracter
+{
+public:
+    PyKwargsExtracter(boost::python::tuple &args_, boost::python::dict &kwargs_, int start_)
+        : args(args_), kwargs(kwargs_), curarg(start_-1),
+          kwargsused(0)
+    {
+    }
+
+    template<typename T>
+    bool extract(T &dst, const char *name)
+    {
+        curarg++;
+        if (boost::python::len(args) > curarg) {
+            dst = boost::python::extract<T>(args[curarg]);
+            return true;
+        } else if (kwargs.has_key(name)) {
+            kwargsused++;
+            dst = boost::python::extract<T>(kwargs.get(name));
+            return true;
+        }
+        return false;
+    }
+
+    template<typename T>
+    T extract(const char *name, const T& defval)
+    {
+        curarg++;
+        if (boost::python::len(args) > curarg) {
+            return boost::python::extract<T>(args[curarg]);
+        } else if (kwargs.has_key(name)) {
+            kwargsused++;
+            return boost::python::extract<T>(kwargs.get(name));
+        } else {
+            return defval;
+        }
+    }
+
+    bool used_all_kwargs() { return kwargsused==boost::python::len(kwargs); }
+
+    boost::python::tuple &args;
+    boost::python::dict &kwargs;
+    int curarg;
+    int kwargsused;
 };
 
 IOService::IOService(bool run) {
@@ -81,12 +128,17 @@ static volatile IOService _instance(true);
 
 GATTResponse::GATTResponse(PyObject* p) :
     GATTPyBase(p),
-    _complete(false), _status(0) {
+    _complete(false), _status(0), _list(false) {
 }
 
 void
 GATTResponse::on_response(boost::python::object data) {
-    _data.append(data);
+    if (_list) {
+        boost::python::list list = boost::python::extract<boost::python::list>(_data);
+        list.append(data);
+    } else {
+        _data = data;
+    }
 }
 
 void
@@ -99,6 +151,13 @@ GATTResponse::notify(uint8_t status) {
       on_response_failed(status);
     }
     _event.set();
+}
+
+void
+GATTResponse::expect_list()
+{
+    _list = true;
+    _data = boost::python::list();
 }
 
 bool
@@ -133,7 +192,7 @@ GATTResponse::status() {
     return _status;
 }
 
-boost::python::list
+boost::python::object
 GATTResponse::received() {
     return _data;
 }
@@ -145,6 +204,10 @@ GATTRequester::GATTRequester(PyObject* p, std::string address, bool do_connect,
     _state(STATE_DISCONNECTED),
     _device(device),
     _address(address),
+    _conn_interval_min(24),
+    _conn_interval_max(40),
+    _slave_latency(0),
+    _supervision_timeout(700),
     _hci_socket(-1),
     _channel(NULL),
     _attrib(NULL) {
@@ -344,49 +407,14 @@ GATTRequester::connect_kwarg(boost::python::tuple args, boost::python::dict kwar
 	// Static method wrapper around connect. First obtain self/this
 	GATTRequester& self = boost::python::extract<GATTRequester&>(args[0]);
 
-	// Argument default values.
-	bool wait=false;
-	std::string channel_type="public";
-	std::string security_level="low";
-	int psm=0;
-	int mtu=0;
-	int kwargsused = 0;
+        PyKwargsExtracter e(args, kwargs, 1);
+        bool wait = e.extract<bool>("wait", false);
+        std::string channel_type = e.extract<std::string>("channel_type", "public");
+        std::string security_level = e.extract<std::string>("security_level", "low");
+        int psm = e.extract<int>("psm", 0);
+        int mtu = e.extract<int>("mtu", 0);
 
-	// Extract each argument either positionally or from the keyword arguments
-	if (boost::python::len(args) > 1) {
-		wait = boost::python::extract<bool>(args[1]);
-	} else if (kwargs.has_key("wait")) {
-		wait = boost::python::extract<bool>(kwargs.get("wait"));
-		kwargsused++;
-	}
-	if (boost::python::len(args) > 2) {
-		channel_type = boost::python::extract<std::string>(args[2]);
-	} else if (kwargs.has_key("channel_type")) {
-		channel_type = boost::python::extract<std::string>(kwargs.get("channel_type"));
-		kwargsused++;
-	}
-	if (boost::python::len(args) > 3) {
-		security_level = boost::python::extract<std::string>(args[3]);
-	} else if (kwargs.has_key("security_level")) {
-		security_level = boost::python::extract<std::string>(kwargs.get("security_level"));
-		kwargsused++;
-	}
-	if (boost::python::len(args) > 4) {
-		psm = boost::python::extract<int>(args[4]);
-	} else if (kwargs.has_key("psm")) {
-		psm = boost::python::extract<int>(kwargs.get("psm"));
-		kwargsused++;
-	}
-	if (boost::python::len(args) > 5) {
-		mtu = boost::python::extract<int>(args[5]);
-	} else if (kwargs.has_key("mtu")) {
-		mtu = boost::python::extract<int>(kwargs.get("mtu"));
-		kwargsused++;
-	}
-
-	// Check that we have used all keyword arguments
-	if (kwargsused != boost::python::len(kwargs))
-            throw BTIOException(EINVAL, "Error in keyword arguments");
+        self.extract_connection_parameters(e);
 
 	// Call the real method
 	self.connect(wait, channel_type, security_level, psm, mtu);
@@ -416,6 +444,59 @@ GATTRequester::disconnect() {
     decref();
 }
 
+static void exchange_mtu_cb(guint8 status, const guint8 *pdu, guint16 len, gpointer user_data)
+{
+    PyGILGuard guard;
+    GATTResponse* response = (GATTResponse*) user_data;
+
+    if (!status && pdu && len>=3) {
+        uint16_t mtu = bt_get_le16(&pdu[1]);
+        response->on_response(boost::python::long_(mtu));
+    }
+
+    response->notify(status);
+    response->decref();
+}
+
+void
+GATTRequester::exchange_mtu_async(uint16_t mtu, GATTResponse* response)
+{
+    check_channel();
+    response->incref();
+    if ( not gatt_exchange_mtu(_attrib, mtu, exchange_mtu_cb, (gpointer)response)) {
+      response->decref();
+      throw BTIOException(ENOMEM, "Exchange MTU failed");
+    }
+}
+
+boost::python::object
+GATTRequester::exchange_mtu(uint16_t mtu)
+{
+    boost::python::object pyresponse = pyGATTResponse();
+    GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
+
+    {
+        PyThreadsGuard guard;
+
+        exchange_mtu_async(mtu, &response);
+
+        if (not response.wait(MAX_WAIT_FOR_PACKET))
+            throw GATTException(ATT_ECODE_TIMEOUT, "Device is not responding!");
+    }
+
+    return response.received();
+}
+
+void
+GATTRequester::set_mtu(uint16_t mtu)
+{
+  if (mtu < ATT_DEFAULT_LE_MTU ||
+      mtu > ATT_MAX_VALUE_LEN) {
+    throw BTIOException(EINVAL, "MTU must be between 23 and 512");
+  }
+  g_attrib_set_mtu(_attrib, mtu);
+}
+
 static void
 read_by_handle_cb(guint8 status, const guint8* data,
         guint16 size, gpointer userp) {
@@ -424,6 +505,7 @@ read_by_handle_cb(guint8 status, const guint8* data,
     GATTResponse* response = (GATTResponse*)userp;
     if (!status && data) {
         PyObject* bytes = PyBytes_FromStringAndSize((const char*)data + 1, size - 1);
+        response->expect_list();
         response->on_response(boost::python::object(boost::python::handle<>(bytes)));
     }
     response->notify(status);
@@ -434,10 +516,13 @@ void
 GATTRequester::read_by_handle_async(uint16_t handle, GATTResponse* response) {
     check_channel();
     response->incref();
-    gatt_read_char(_attrib, handle, read_by_handle_cb, (gpointer)response);
+    if ( not gatt_read_char(_attrib, handle, read_by_handle_cb, (gpointer)response)) {
+      response->decref();
+      throw BTIOException(ENOMEM, "Read characteristic failed");
+    }
 }
 
-boost::python::list
+boost::python::object
 GATTRequester::read_by_handle(uint16_t handle) {
     boost::python::object pyresponse = pyGATTResponse();
     GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
@@ -472,6 +557,8 @@ read_by_uuid_cb(guint8 status, const guint8* data,
         return;
     }
 
+    response->expect_list();
+
     for (int i=0; i<list->num; i++) {
         uint8_t* item = list->data[i];
 
@@ -498,12 +585,15 @@ GATTRequester::read_by_uuid_async(std::string uuid, GATTResponse* response) {
         throw BTIOException(EINVAL, "Invalid UUID\n");
 
     response->incref();
-    gatt_read_char_by_uuid(_attrib, start, end, &btuuid, read_by_uuid_cb,
-                           (gpointer)response);
+    if ( not gatt_read_char_by_uuid(_attrib, start, end, &btuuid, read_by_uuid_cb,
+                                    (gpointer)response)) {
+      response->decref();
+      throw BTIOException(ENOMEM, "Read characteristic failed");
+    }
 
 }
 
-boost::python::list
+boost::python::object
 GATTRequester::read_by_uuid(std::string uuid) {
     boost::python::object pyresponse = pyGATTResponse();
     GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
@@ -528,6 +618,7 @@ write_by_handle_cb(guint8 status, const guint8* data,
     GATTResponse* response = (GATTResponse*)userp;
     if (status == 0 && data) {
         PyObject* bytes = PyBytes_FromStringAndSize((const char*)data, size);
+        response->expect_list();
         response->on_response(boost::python::object(boost::python::handle<>(bytes)));
     }
     response->notify(status);
@@ -540,11 +631,14 @@ GATTRequester::write_by_handle_async(uint16_t handle, std::string data,
 
     check_channel();
     response->incref();
-    gatt_write_char(_attrib, handle, (const uint8_t*)data.data(), data.size(),
-                    write_by_handle_cb, (gpointer)response);
+    if ( not gatt_write_char(_attrib, handle, (const uint8_t*)data.data(), data.size(),
+                             write_by_handle_cb, (gpointer)response)) {
+      response->decref();
+      throw BTIOException(ENOMEM, "Write characteristic failed");
+    }
 }
 
-boost::python::list
+boost::python::object
 GATTRequester::write_by_handle(uint16_t handle, std::string data) {
     boost::python::object pyresponse = pyGATTResponse();
     GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
@@ -564,8 +658,42 @@ GATTRequester::write_by_handle(uint16_t handle, std::string data) {
 void
 GATTRequester::write_cmd(uint16_t handle, std::string data) {
     check_channel();
-    gatt_write_cmd(_attrib, handle, (const uint8_t*)data.data(), data.size(),
-                   NULL, NULL);
+    if ( not gatt_write_cmd(_attrib, handle, (const uint8_t*)data.data(), data.size(),
+                            NULL, NULL)) {
+      throw BTIOException(ENOMEM, "Write command failed");
+    }
+
+}
+
+void
+GATTRequester::enable_notifications_async(uint16_t handle, bool notifications, bool indications,
+                                          GATTResponse* response) {
+    check_channel();
+    uint8_t val[2] = { 0, 0 };
+    if (notifications) val[0] |= GATT_CLIENT_CHARAC_CFG_NOTIF_BIT;
+    if (indications) val[0] |= GATT_CLIENT_CHARAC_CFG_IND_BIT;
+    response->incref();
+    if ( not gatt_write_char(_attrib, handle, val, 2,
+                             write_by_handle_cb, (gpointer)response)) {
+      response->decref();
+      throw BTIOException(ENOMEM, "Write characteristic failed");
+    }
+
+}
+
+void
+GATTRequester::enable_notifications(uint16_t handle, bool notifications, bool indications) {
+    boost::python::object pyresponse = pyGATTResponse();
+    GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
+
+    {
+        PyThreadsGuard guard;
+
+        enable_notifications_async(handle, notifications, indications, &response);
+
+        if (not response.wait(MAX_WAIT_FOR_PACKET))
+            throw GATTException(ATT_ECODE_TIMEOUT, "Device is not responding!");
+    }
 }
 
 void
@@ -585,6 +713,78 @@ GATTRequester::check_channel() {
     throw BTIOException(ETIMEDOUT, "Channel or attrib not ready");
 }
 
+boost::python::object
+GATTRequester::update_connection_parameters_kwarg(boost::python::tuple args, boost::python::dict kwargs)
+{
+    GATTRequester& self = boost::python::extract<GATTRequester&>(args[0]);
+    PyKwargsExtracter e(args, kwargs, 1);
+    self.extract_connection_parameters(e);
+    self.update_connection_parameters();
+    return boost::python::object();
+}
+
+void
+GATTRequester::extract_connection_parameters(PyKwargsExtracter &e)
+{
+    uint16_t conn_interval_min = _conn_interval_min;
+    uint16_t conn_interval_max = _conn_interval_max;
+    uint16_t slave_latency = _slave_latency;
+    uint16_t supervision_timeout = _supervision_timeout;
+
+    if (e.extract<uint16_t>(conn_interval_min, "conn_interval_min")) {
+        if ((conn_interval_min<0x0006 || conn_interval_min>0x0c80) &&
+            conn_interval_min!=0xffff)
+            throw BTIOException(EINVAL, "conn_interval_min must be between 6 and 0xc80, or 0xffff");
+    }
+    if (e.extract<uint16_t>(conn_interval_max, "conn_interval_max")) {
+        if ((conn_interval_max<0x0006 || conn_interval_max>0x0c80) &&
+            conn_interval_max!=0xffff)
+            throw BTIOException(EINVAL, "conn_interval_max must be between 6 and 0xc80, or 0xffff");
+    }
+    if (conn_interval_min!=0xffff && conn_interval_min>conn_interval_max)
+        throw BTIOException(EINVAL, "conn_interval_max must be greater then or equal to conn_interval_min");
+    if (e.extract<uint16_t>(slave_latency, "slave_latency")) {
+        if (slave_latency>0x01f3)
+            throw BTIOException(EINVAL, "slave_latency must be between 0 and 0x1f3");
+    }
+    if (e.extract<uint16_t>(supervision_timeout, "supervision_timeout")) {
+        if ((supervision_timeout<0x000a || supervision_timeout>0x0c80) &&
+            supervision_timeout!=0xffff)
+            throw BTIOException(EINVAL, "supervision_timeout must be between 0xa and 0xc80, or 0xffff");
+    }
+
+    // Check that we have used all keyword arguments
+    if (!e.used_all_kwargs())
+        throw BTIOException(EINVAL, "Error in keyword arguments");
+
+    _conn_interval_min = conn_interval_min;
+    _conn_interval_max = conn_interval_max;
+    _slave_latency = slave_latency;
+    _supervision_timeout = supervision_timeout;
+}
+
+void
+GATTRequester::update_connection_parameters()
+{
+    // Update connection settings (supervisor timeut > 0.42 s)
+    int l2cap_sock = g_io_channel_unix_get_fd(_channel);
+    struct l2cap_conninfo info;
+    socklen_t info_size = sizeof(info);
+
+    getsockopt(l2cap_sock, SOL_L2CAP, L2CAP_CONNINFO, &info, &info_size);
+    int handle = info.hci_handle;
+
+    int retval = hci_le_conn_update(
+            _hci_socket, handle,
+            _conn_interval_min, _conn_interval_max,
+            _slave_latency, _supervision_timeout, 25000);
+    if (retval < 0) {
+        std::string msg = "Could not update HCI connection: ";
+        msg += strerror(errno);
+        throw BTIOException(errno, msg);
+    }
+}
+
 static void
 discover_primary_cb(guint8 status, GSList *services, void *userp) {
 
@@ -595,6 +795,8 @@ discover_primary_cb(guint8 status, GSList *services, void *userp) {
         response->decref();
         return;
     }
+
+    response->expect_list();
 
     for (GSList * l = services; l; l = l->next) {
         struct gatt_primary *prim = (gatt_primary*) l->data;
@@ -621,7 +823,7 @@ GATTRequester::discover_primary_async(GATTResponse* response) {
     }
 }
 
-boost::python::list GATTRequester::discover_primary() {
+boost::python::object GATTRequester::discover_primary() {
     boost::python::object pyresponse = pyGATTResponse();
     GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
 
@@ -631,6 +833,63 @@ boost::python::list GATTRequester::discover_primary() {
 	discover_primary_async(&response);
 
 	if (not response.wait(5 * MAX_WAIT_FOR_PACKET))
+            throw GATTException(ATT_ECODE_TIMEOUT, "Device is not responding!");
+    }
+
+    return response.received();
+}
+
+/* Included Service Discovery
+
+ */
+static void
+find_included_cb(guint8 status, GSList *includes, void *userp) {
+
+    PyGILGuard guard;
+    GATTResponse* response = (GATTResponse*)userp;
+    if (status || !includes) {
+        response->notify(status);
+        response->decref();
+        return;
+    }
+
+    response->expect_list();
+
+    for (GSList * l = includes; l; l = l->next) {
+        struct gatt_included *incl = (gatt_included*) l->data;
+        boost::python::dict sdescr;
+        sdescr["uuid"] = incl->uuid;
+        sdescr["handle"] = incl->handle;
+        sdescr["start"] = incl->range.start;
+        sdescr["end"] = incl->range.end;
+        response->on_response(sdescr);
+    }
+
+    response->notify(status);
+    response->decref();
+}
+
+void
+GATTRequester::find_included_async(GATTResponse* response, int start, int end) {
+    check_connected();
+    response->incref();
+    if( not gatt_find_included(
+            _attrib, start, end, find_included_cb, (gpointer)response)) {
+        response->decref();
+        throw BTIOException(ENOMEM, "Find included failed");
+    }
+}
+
+boost::python::object GATTRequester::find_included(int start, int end) {
+    boost::python::object pyresponse = pyGATTResponse();
+    GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
+
+    {
+        PyThreadsGuard guard;
+
+        find_included_async(&response, start, end);
+
+        if (not response.wait(5 * MAX_WAIT_FOR_PACKET))
             throw GATTException(ATT_ECODE_TIMEOUT, "Device is not responding!");
     }
 
@@ -649,6 +908,8 @@ static void discover_char_cb(guint8 status, GSList *characteristics,
         response->decref();
         return;
     }
+
+    response->expect_list();
 
     for (GSList * l = characteristics; l; l = l->next) {
         struct gatt_char *chars = (gatt_char*) l->data;
@@ -669,23 +930,27 @@ void GATTRequester::discover_characteristics_async(GATTResponse* response,
     check_connected();
 
     if (uuid_str.size() == 0) {
-        //TODO handle error
         response->incref();
-        gatt_discover_char(_attrib, start, end, NULL, discover_char_cb,
-                (gpointer) response);
+        if ( not gatt_discover_char(_attrib, start, end, NULL, discover_char_cb,
+                                    (gpointer) response)) {
+          response->decref();
+          throw BTIOException(ENOMEM, "Discover characteristics failed");
+        }
     } else {
         bt_uuid_t uuid;
         if (bt_string_to_uuid(&uuid, uuid_str.c_str()) < 0) {
             throw BTIOException(EINVAL, "Invalid UUID");
         }
-        //TODO handle error
         response->incref();
-        gatt_discover_char(_attrib, start, end, &uuid, discover_char_cb,
-                (gpointer) response);
+        if ( not gatt_discover_char(_attrib, start, end, &uuid, discover_char_cb,
+                                    (gpointer) response)) {
+          response->decref();
+          throw BTIOException(ENOMEM, "Discover characteristics failed");
+        }
     }
 }
 
-boost::python::list GATTRequester::discover_characteristics(int start, int end,
+boost::python::object GATTRequester::discover_characteristics(int start, int end,
         std::string uuid_str) {
     boost::python::object pyresponse = pyGATTResponse();
     GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
@@ -694,6 +959,75 @@ boost::python::list GATTRequester::discover_characteristics(int start, int end,
         PyThreadsGuard guard;
 
         discover_characteristics_async(&response, start, end, uuid_str);
+
+        if (not response.wait(5 * MAX_WAIT_FOR_PACKET))
+            throw GATTException(ATT_ECODE_TIMEOUT, "Device is not responding!");
+    }
+
+    return response.received();
+}
+
+/* Descriptors Discovery
+
+ */
+static void discover_desc_cb(guint8 status, GSList *descriptors,
+        void *user_data) {
+    PyGILGuard guard;
+    GATTResponse* response = (GATTResponse*) user_data;
+    if (status || !descriptors) {
+        response->notify(status);
+        response->decref();
+        return;
+    }
+
+    response->expect_list();
+
+    for (GSList * l = descriptors; l; l = l->next) {
+        struct gatt_desc *descs = (gatt_desc*) l->data;
+        boost::python::dict adescr;
+        adescr["uuid"] = descs->uuid;
+        adescr["handle"] = descs->handle;
+        response->on_response(adescr);
+    }
+
+    response->notify(status);
+    response->decref();
+}
+
+void GATTRequester::discover_descriptors_async(GATTResponse* response,
+        int start, int end, std::string uuid_str) {
+    check_connected();
+
+    if (uuid_str.size() == 0) {
+        response->incref();
+        if ( not gatt_discover_desc(_attrib, start, end, NULL, discover_desc_cb,
+                                    (gpointer) response)) {
+          response->decref();
+          throw BTIOException(ENOMEM, "Discover descriptors failed");
+        }
+    } else {
+        bt_uuid_t uuid;
+        if (bt_string_to_uuid(&uuid, uuid_str.c_str()) < 0) {
+            throw BTIOException(EINVAL, "Invalid UUID");
+        }
+        response->incref();
+        if ( not gatt_discover_desc(_attrib, start, end, &uuid, discover_char_cb,
+                                    (gpointer) response)) {
+          response->decref();
+          throw BTIOException(ENOMEM, "Discover descriptors failed");
+        }
+    }
+}
+
+boost::python::object GATTRequester::discover_descriptors(int start, int end,
+        std::string uuid_str) {
+    boost::python::object pyresponse = pyGATTResponse();
+    GATTResponse &response = boost::python::extract<GATTResponse&>(pyresponse)();
+
+    {
+        PyThreadsGuard guard;
+
+        discover_descriptors_async(&response, start, end, uuid_str);
 
         if (not response.wait(5 * MAX_WAIT_FOR_PACKET))
             throw GATTException(ATT_ECODE_TIMEOUT, "Device is not responding!");


### PR DESCRIPTION
This is now the meat of what I wanted to add for my own project.

In particular, descriptor discovery is necessary to be able to tell the device to send notifications. (And the convenience method enable_notifications further simplifies this - there is example code out there that gets the underlying call wrong in a way that some, but not all, devices will reject and ignore.)

And the connection parameter update (which I note used to be done automatically on connect, but with a fixed, non-configurable set of parameters, but has now been removed) is sometimes required to enable service discovery to complete quickly then drop down to a slower, low power configuration. (Particularly needed when the device itself gives you a grace period to do discovery before itself forcing you into the slow configuration, and the default connection settings aren't fast enough to get that done before the device does so.)

I've also tidied up the error handling (and removed the associated TODOs.)

After this, I think I should update the docs accordingly, but unless I discover some new problem I'm almost done.