### PR TITLE
protect GAttrib from some multi-threaded accesses

### DIFF
--- a/src/bluez/attrib/gattrib.h
+++ b/src/bluez/attrib/gattrib.h
@@ -34,6 +34,11 @@ extern "C" {
 struct _GAttrib;
 typedef struct _GAttrib GAttrib;
 
+struct _GAttribLock {
+  void (*lockfn)(struct _GAttribLock *l);
+  void (*unlockfn)(struct _GAttribLock *l);
+};
+
 typedef void (*GAttribResultFunc) (guint8 status, const guint8 *pdu,
 					guint16 len, gpointer user_data);
 typedef void (*GAttribDisconnectFunc)(gpointer user_data);
@@ -42,6 +47,7 @@ typedef void (*GAttribNotifyFunc)(const guint8 *pdu, guint16 len,
 							gpointer user_data);
 
 GAttrib *g_attrib_new(GIOChannel *io, guint16 mtu);
+GAttrib *g_attrib_withlock_new(GIOChannel *io, guint16 mtu, struct _GAttribLock *lk);
 GAttrib *g_attrib_ref(GAttrib *attrib);
 void g_attrib_unref(GAttrib *attrib);
 

--- a/src/gattlib.cpp
+++ b/src/gattlib.cpp
@@ -332,7 +332,7 @@ connect_cb(GIOChannel* channel, GError* err, gpointer userp) {
     else if (cid == ATT_CID)
         mtu = ATT_DEFAULT_LE_MTU;
 
-    request->_attrib = g_attrib_new(channel, mtu);
+    request->_attrib = g_attrib_withlock_new(channel, mtu, &request->attriblocker);
 
     request->incref();
     g_attrib_register(request->_attrib, ATT_OP_HANDLE_NOTIFY,

--- a/src/gattlib.h
+++ b/src/gattlib.h
@@ -175,6 +175,24 @@ private:
 	int _hci_socket;
 	GIOChannel* _channel;
 	GAttrib* _attrib;
+	class AttribLocker : public _GAttribLock
+	{
+	public:
+		AttribLocker()
+		{
+			lockfn = &slock;
+			unlockfn = &sunlock;
+		}
+		static void slock(struct _GAttribLock *lk)
+		{
+			((AttribLocker*)lk)->_mutex.lock();
+		}
+		static void sunlock(struct _GAttribLock *lk)
+		{
+			((AttribLocker*)lk)->_mutex.unlock();
+		}
+		boost::mutex _mutex;
+	} attriblocker;
 	Event _ready;
 };
 


### PR DESCRIPTION
Ok, I knew thread safety was probably going to come back...

Turns out connection and discovery is highly unreliable now and often just stalls. The particular problem is that sending a new request adds an output watch to wake up the worker thread which sends the actual packet. The watch is only added when we grow the request queue from 0 to 1 items, and only if the watch isn't already present, which we track by recording the watch id that GLib returns for it within the GAttrib structure.

However the act of adding the watch can cause the worker thread to wake, send the packet, and clear the watch id variable all before we have chance to save the new watch id value within the source thread. Which we then do anyway. Which makes it look like the watch is already added when it isn't, and prevents any future packets from being sent.

Again, because bluez is just not designed for multi-threaded working, this requires much of the necessary support to be added to it directly. I've protected as much of the other accesses as seems necessary and tried not to introduce any deadlocks in the process. At least, my device connects and starts up quickly and reliable now.